### PR TITLE
Adding .gitignore and makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+out
+labels.txt

--- a/makefile
+++ b/makefile
@@ -1,0 +1,12 @@
+SRC_DIR=src
+OUT_DIR=out
+OUTFILE=kid-icarusnes.sfc
+
+$(TARGETS): | $(OUT_DIR)
+
+default: $(OUT_DIR)/main.o
+	ld65  -C $(SRC_DIR)/hirom.cfg -o $(OUT_DIR)/$(OUTFILE) $(OUT_DIR)/main.o
+
+$(OUT_DIR)/main.o: $(SRC_DIR)/main.asm
+	mkdir -p $(OUT_DIR)
+	ca65 $(SRC_DIR)/main.asm -o $(OUT_DIR)/main.o


### PR DESCRIPTION
Added a .gitignore so that the out/ directory isn't tracked at all by git.
Added a makefile as an alternative to the build.sh. In theory this is probably more universal. Also removed the switch to just build release version by default. Also set the ld65 to not generate a labels.txt. Also it doesn't bother creating out/msu directory or copying anything there, it just creates it in out/

Neither of these changes should affect your workflow or otherwise change what you do. If you continue to use build.sh, nothing will change.